### PR TITLE
Added compatibily for QT6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+# .pre-commit-config.yaml
+repos:
+-   repo: https://github.com/mattlqx/pre-commit-search-and-replace
+    rev: v1.1.3
+    hooks:
+    -   id: search-and-replace
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0  # this is optional, use `pre-commit autoupdate` to get the latest rev!
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+    -   id: black

--- a/.pre-commit-search-and-replace.yaml
+++ b/.pre-commit-search-and-replace.yaml
@@ -1,0 +1,4 @@
+- search: PySide6
+  replacement: PySide
+- search: PySide
+  replacement: PySide

--- a/.pre-commit-search-and-replace.yaml
+++ b/.pre-commit-search-and-replace.yaml
@@ -1,4 +1,4 @@
-- search: PySide6
+- search: PySide
   replacement: PySide
 - search: PySide
   replacement: PySide

--- a/FCBinding.py
+++ b/FCBinding.py
@@ -32,9 +32,9 @@ from pyqtribbon import RibbonBar
 import FreeCAD as App
 import FreeCADGui as Gui
 
-from PySide6.QtCore import Qt, QTimer
-from PySide6.QtWidgets import QToolButton, QToolBar, QDockWidget, QWidget, QSizePolicy
-from PySide6.QtGui import QIcon
+from PySide.QtCore import Qt, QTimer
+from PySide.QtWidgets import QToolButton, QToolBar, QDockWidget, QWidget, QSizePolicy
+from PySide.QtGui import QIcon
 
 
 mw = Gui.getMainWindow()

--- a/FCBinding.py
+++ b/FCBinding.py
@@ -23,14 +23,18 @@
 import os
 import json
 
-from PySide.QtCore import Qt, QTimer
-from PySide.QtWidgets import QToolButton, QToolBar, QDockWidget, QWidget, QSizePolicy
-from PySide.QtGui import QIcon
+# from PySide.QtCore import Qt, QTimer
+# from PySide.QtWidgets import QToolButton, QToolBar, QDockWidget, QWidget, QSizePolicy
+# from PySide.QtGui import QIcon
 
 from pyqtribbon import RibbonBar
 
 import FreeCAD as App
 import FreeCADGui as Gui
+
+from PySide6.QtCore import Qt, QTimer
+from PySide6.QtWidgets import QToolButton, QToolBar, QDockWidget, QWidget, QSizePolicy
+from PySide6.QtGui import QIcon
 
 
 mw = Gui.getMainWindow()

--- a/FCBinding.py
+++ b/FCBinding.py
@@ -23,9 +23,9 @@
 import os
 import json
 
-from PySide2.QtCore import Qt, QTimer
-from PySide2.QtWidgets import QToolButton, QToolBar, QDockWidget, QWidget, QSizePolicy
-from PySide2.QtGui import QIcon
+from PySide.QtCore import Qt, QTimer
+from PySide.QtWidgets import QToolButton, QToolBar, QDockWidget, QWidget, QSizePolicy
+from PySide.QtGui import QIcon
 
 from pyqtribbon import RibbonBar
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Download this repository, extract the folder and copy it to the `Mod` folder of 
 1. Create a macro.
 1. Paste this code in to macro.
     ```python
-    from PySide2 import QtCore, QtGui, QtWidgets
+    from PySide import QtCore, QtGui, QtWidgets
     mw = FreeCADGui.getMainWindow()
     mw.menuBar().show()
 

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
+
+  <name>FreeCAD Ribbon</name>
+
+  <description>Aa Ribbon for FreeCAD</description>
+
+  <version>0.0.1</version>
+
+  <date>2024-01-03</date>
+
+  <maintainer email="paul.ebbers@gmail.com">Paul Ebbers</maintainer>
+
+  <license file="LICENSE">MIT</license>
+
+  <pythonmin>3.8.0</pythonmin>
+
+  <url type="website">https://github.com/geolta/FreeCAD-Ribbon/wiki</url>
+
+  <url branch="main" type="repository">https://github.com/geolta/FreeCAD-Ribbon</url>
+
+  <url type="readme">hhttps://github.com/geolta/FreeCAD-Ribbon/blob/main/README.md</url>
+
+  <icon></icon>
+
+  <content>
+    <workbench>
+      <freecadmin>0.21.0</freecadmin>
+      <!-- <icon>Resources/Icons/BillOfMaterialsWB.svg</icon> -->
+      <!-- <depend optional="False" type="automatic">Spreadsheet</depend>
+      <depend optional="False" type="automatic">TechDraw</depend>
+      <depend optional="True" type="python">openpyxl</depend>
+      <depend optional="False" type="python">inspect</depend>
+      <depend optional="False" type="python">tkinter</depend>
+      <depend optional="False" type="python">getpass</depend>
+      <depend optional="False" type="python">matplotlib</depend>
+      <depend optional="False" type="python">math</depend> -->
+      <!-- <classname>BillOfMaterialsWB</classname> -->
+      <subdirectory>./</subdirectory>
+    </workbench>
+  </content>
+
+</package>

--- a/package.xml
+++ b/package.xml
@@ -27,7 +27,7 @@
     <workbench>
       <freecadmin>0.21.0</freecadmin>
       <!-- <icon>Resources/Icons/BillOfMaterialsWB.svg</icon> -->
-      <depend optional="True" type="python">pyqtribbon</depend>
+      <!-- <depend optional="True" type="python">pyqtribbon</depend> -->
       <!-- <classname>BillOfMaterialsWB</classname> -->
       <subdirectory>./</subdirectory>
     </workbench>

--- a/package.xml
+++ b/package.xml
@@ -27,14 +27,7 @@
     <workbench>
       <freecadmin>0.21.0</freecadmin>
       <!-- <icon>Resources/Icons/BillOfMaterialsWB.svg</icon> -->
-      <!-- <depend optional="False" type="automatic">Spreadsheet</depend>
-      <depend optional="False" type="automatic">TechDraw</depend>
-      <depend optional="True" type="python">openpyxl</depend>
-      <depend optional="False" type="python">inspect</depend>
-      <depend optional="False" type="python">tkinter</depend>
-      <depend optional="False" type="python">getpass</depend>
-      <depend optional="False" type="python">matplotlib</depend>
-      <depend optional="False" type="python">math</depend> -->
+      <depend optional="True" type="python">pyqtribbon</depend>
       <!-- <classname>BillOfMaterialsWB</classname> -->
       <subdirectory>./</subdirectory>
     </workbench>

--- a/package.xml
+++ b/package.xml
@@ -5,7 +5,7 @@
 
   <description>Aa Ribbon for FreeCAD</description>
 
-  <version>0.0.1</version>
+  <version>0.0.2</version>
 
   <date>2024-01-03</date>
 

--- a/pyqtribbon/category.py
+++ b/pyqtribbon/category.py
@@ -1,6 +1,6 @@
 import typing
 
-from PySide2 import QtCore, QtGui, QtWidgets
+from PySide import QtCore, QtGui, QtWidgets
 
 from .constants import RibbonCategoryStyle
 from .panel import RibbonPanel
@@ -45,7 +45,8 @@ class RibbonCategoryLayoutWidget(QtWidgets.QFrame):
 
         # Contents of the category scroll area
         self._categoryScrollAreaContents = RibbonCategoryScrollAreaContents()  # type: ignore
-        self._categoryScrollAreaContents.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)  # type: ignore
+        self._categoryScrollAreaContents.setSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)  # type: ignore
         self._categoryLayout = QtWidgets.QHBoxLayout(self._categoryScrollAreaContents)
         self._categoryLayout.setContentsMargins(0, 0, 0, 0)
         self._categoryLayout.setSpacing(5)

--- a/pyqtribbon/constants.py
+++ b/pyqtribbon/constants.py
@@ -1,6 +1,6 @@
 from enum import IntEnum
 
-from PySide2 import QtGui
+from PySide import QtGui
 
 
 class RibbonCategoryStyle(IntEnum):

--- a/pyqtribbon/gallery.py
+++ b/pyqtribbon/gallery.py
@@ -1,6 +1,6 @@
 import typing
 
-from PySide2 import QtCore, QtGui, QtWidgets
+from PySide import QtCore, QtGui, QtWidgets
 
 from .menu import RibbonPermanentMenu
 from .separator import RibbonHorizontalSeparator

--- a/pyqtribbon/gallery.py
+++ b/pyqtribbon/gallery.py
@@ -1,6 +1,6 @@
 import typing
 
-from PySide import QtCore, QtGui, QtWidgets
+from PySide2 import QtCore, QtGui, QtWidgets
 
 from .menu import RibbonPermanentMenu
 from .separator import RibbonHorizontalSeparator
@@ -141,9 +141,9 @@ class RibbonGallery(QtWidgets.QFrame):
 
         self._moreButton.clicked.connect(self.showPopup)  # type: ignore
 
-    def _handlePopupAction(self, action: QtWidgets.QAction) -> None:
+    def _handlePopupAction(self, action: QtWidgets.QWidgetAction) -> None:
         """Handle a popup action."""
-        if isinstance(action, QtWidgets.QAction):
+        if isinstance(action, QtWidgets.QWidgetAction):
             action.triggered.connect(self.hidePopupWidget)  # type: ignore
 
     def resizeEvent(self, a0: QtGui.QResizeEvent) -> None:

--- a/pyqtribbon/logger.py
+++ b/pyqtribbon/logger.py
@@ -5,7 +5,7 @@ import logging
 import sys
 import traceback
 
-from PySide2 import QtCore, QtWidgets
+from PySide import QtCore, QtWidgets
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.StreamHandler(stream=sys.stdout))

--- a/pyqtribbon/menu.py
+++ b/pyqtribbon/menu.py
@@ -1,6 +1,6 @@
 import typing
 
-from PySide2 import QtCore, QtGui, QtWidgets
+from PySide import QtCore, QtGui, QtWidgets
 
 
 class RibbonMenu(QtWidgets.QMenu):

--- a/pyqtribbon/menu.py
+++ b/pyqtribbon/menu.py
@@ -1,6 +1,6 @@
 import typing
 
-from PySide import QtCore, QtGui, QtWidgets
+from PySide2 import QtCore, QtGui, QtWidgets
 
 
 class RibbonMenu(QtWidgets.QMenu):
@@ -105,13 +105,12 @@ class RibbonPermanentMenu(RibbonMenu):
     """
     A permanent menu.
     """
-
-    actionAdded = QtCore.Signal(QtWidgets.QAction)
+    actionAdded = QtCore.Signal(QtWidgets.QWidgetAction)
 
     def hideEvent(self, a0: QtGui.QHideEvent) -> None:
         self.show()
 
-    def addAction(self, *args, **kwargs) -> QtWidgets.QAction:
+    def addAction(self, *args, **kwargs) -> QtWidgets.QWidgetAction:
         action = super().addAction(*args, **kwargs)
         self.actionAdded.emit(action)
         return action

--- a/pyqtribbon/panel.py
+++ b/pyqtribbon/panel.py
@@ -5,7 +5,7 @@ import re
 from typing import Any, Callable, Dict, List, Union, overload
 
 import numpy as np
-from PySide2 import QtCore, QtGui, QtWidgets
+from PySide import QtCore, QtGui, QtWidgets
 
 from .constants import ColumnWise, Large, Medium, RibbonButtonStyle, Small
 from .gallery import RibbonGallery
@@ -44,8 +44,8 @@ class RibbonGridLayoutManager(object):
         if mode == ColumnWise:
             for row in range(self.cells.shape[0] - rowSpan + 1):
                 for col in range(self.cells.shape[1] - colSpan + 1):
-                    if self.cells[row : row + rowSpan, col : col + colSpan].all():
-                        self.cells[row : row + rowSpan, col : col + colSpan] = False
+                    if self.cells[row: row + rowSpan, col: col + colSpan].all():
+                        self.cells[row: row + rowSpan, col: col + colSpan] = False
                         return row, col
         else:
             for col in range(self.cells.shape[1]):
@@ -62,7 +62,7 @@ class RibbonGridLayoutManager(object):
             cols -= 1
             colSpan1 -= 1
         self.cells = np.append(self.cells, np.ones((self.rows, colSpan1), dtype=bool), axis=1)
-        self.cells[:rowSpan, cols : cols + colSpan] = False
+        self.cells[:rowSpan, cols: cols + colSpan] = False
         return 0, cols
 
 
@@ -512,7 +512,8 @@ class RibbonPanel(QtWidgets.QFrame):
         # Create the new method
         return functools.partial(base_method, rowSpan=rowSpan)
 
-    addComboBox = functools.partialmethod(_addAnyWidget, cls=QtWidgets.QComboBox, initializer=QtWidgets.QComboBox.addItems)  # fmt: skip
+    addComboBox = functools.partialmethod(_addAnyWidget, cls=QtWidgets.QComboBox,
+                                          initializer=QtWidgets.QComboBox.addItems)  # fmt: skip
     addFontComboBox = functools.partialmethod(_addAnyWidget, cls=QtWidgets.QFontComboBox)
     addLineEdit = functools.partialmethod(_addAnyWidget, cls=QtWidgets.QLineEdit)
     addTextEdit = functools.partialmethod(_addAnyWidget, cls=QtWidgets.QTextEdit)

--- a/pyqtribbon/panel.pyi
+++ b/pyqtribbon/panel.pyi
@@ -3,14 +3,17 @@ from __future__ import annotations
 from typing import Any, Callable, Dict, Iterable, List, Union, overload
 
 import numpy as np
-from PySide2 import QtCore, QtGui, QtWidgets
+from PySide import QtCore, QtGui, QtWidgets
 
 from .constants import ColumnWise, Large, RibbonButtonStyle, Small
 from .gallery import RibbonGallery
 from .separator import RibbonSeparator
 from .toolbutton import RibbonToolButton
 
-class RibbonPanelTitle(QtWidgets.QLabel): ...
+
+class RibbonPanelTitle(QtWidgets.QLabel):
+    ...
+
 
 class RibbonGridLayoutManager(object):
     rows: int
@@ -19,11 +22,15 @@ class RibbonGridLayoutManager(object):
     def __init__(self, rows: int): ...
     def request_cells(self, rowSpan: int = 1, colSpan: int = 1, mode=ColumnWise): ...
 
+
 class RibbonPanelItemWidget(QtWidgets.QFrame):
     def __init__(self, parent=None): ...
     def addWidget(self, widget): ...
 
-class RibbonPanelOptionButton(QtWidgets.QToolButton): ...
+
+class RibbonPanelOptionButton(QtWidgets.QToolButton):
+    ...
+
 
 class RibbonPanel(QtWidgets.QFrame):
     _maxRows: int = 6
@@ -64,6 +71,7 @@ class RibbonPanel(QtWidgets.QFrame):
     def setPanelOptionToolTip(self, text: str): ...
     def rowHeight(self) -> int: ...
     def addWidgetsBy(self, data: Dict[str, Dict]) -> Dict[str, QtWidgets.QWidget]: ...
+
     def addWidget(
         self,
         widget: QtWidgets.QWidget,
@@ -74,6 +82,7 @@ class RibbonPanel(QtWidgets.QFrame):
         alignment=QtCore.Qt.AlignCenter,
         fixedHeight: Union[bool, float] = False,
     ) -> QtWidgets.QWidget | Any: ...
+
     def addSmallWidget(
         self,
         widget: QtWidgets.QWidget,
@@ -83,6 +92,7 @@ class RibbonPanel(QtWidgets.QFrame):
         alignment=QtCore.Qt.AlignCenter,
         fixedHeight: Union[bool, float] = False,
     ) -> QtWidgets.QWidget | Any: ...
+
     def addMediumWidget(
         self,
         widget: QtWidgets.QWidget,
@@ -92,6 +102,7 @@ class RibbonPanel(QtWidgets.QFrame):
         alignment=QtCore.Qt.AlignCenter,
         fixedHeight: Union[bool, float] = False,
     ) -> QtWidgets.QWidget | Any: ...
+
     def addLargeWidget(
         self,
         widget: QtWidgets.QWidget,
@@ -104,6 +115,7 @@ class RibbonPanel(QtWidgets.QFrame):
     def removeWidget(self, widget: QtWidgets.QWidget): ...
     def widget(self, index: int) -> QtWidgets.QWidget: ...
     def widgets(self) -> List[QtWidgets.QWidget]: ...
+
     def addButton(
         self,
         text: str = None,
@@ -121,6 +133,7 @@ class RibbonPanel(QtWidgets.QFrame):
         alignment=QtCore.Qt.AlignCenter,
         fixedHeight: Union[bool, float] = False,
     ) -> RibbonToolButton: ...
+
     def addSmallButton(
         self,
         text: str = None,
@@ -137,6 +150,7 @@ class RibbonPanel(QtWidgets.QFrame):
         alignment=QtCore.Qt.AlignCenter,
         fixedHeight: Union[bool, float] = False,
     ) -> RibbonToolButton: ...
+
     def addMediumButton(
         self,
         text: str = None,
@@ -153,6 +167,7 @@ class RibbonPanel(QtWidgets.QFrame):
         alignment=QtCore.Qt.AlignCenter,
         fixedHeight: Union[bool, float] = False,
     ) -> RibbonToolButton: ...
+
     def addLargeButton(
         self,
         text: str = None,
@@ -169,6 +184,7 @@ class RibbonPanel(QtWidgets.QFrame):
         alignment=QtCore.Qt.AlignCenter,
         fixedHeight: Union[bool, float] = False,
     ) -> RibbonToolButton: ...
+
     def addToggleButton(
         self,
         text: str = None,
@@ -185,6 +201,7 @@ class RibbonPanel(QtWidgets.QFrame):
         alignment=QtCore.Qt.AlignCenter,
         fixedHeight: Union[bool, float] = False,
     ) -> RibbonToolButton: ...
+
     def addSmallToggleButton(
         self,
         text: str = None,
@@ -200,6 +217,7 @@ class RibbonPanel(QtWidgets.QFrame):
         alignment=QtCore.Qt.AlignCenter,
         fixedHeight: Union[bool, float] = False,
     ) -> RibbonToolButton: ...
+
     def addMediumToggleButton(
         self,
         text: str = None,
@@ -215,6 +233,7 @@ class RibbonPanel(QtWidgets.QFrame):
         alignment=QtCore.Qt.AlignCenter,
         fixedHeight: Union[bool, float] = False,
     ) -> RibbonToolButton: ...
+
     def addLargeToggleButton(
         self,
         text: str = None,
@@ -246,6 +265,7 @@ class RibbonPanel(QtWidgets.QFrame):
         **kwargs,
     ) -> QtWidgets.QWidget: ...
     def __getattr__(self, method: str) -> Callable: ...
+
     def addComboBox(
         self,
         items: Iterable[str],
@@ -259,6 +279,7 @@ class RibbonPanel(QtWidgets.QFrame):
     addSmallComboBox = addComboBox
     addMediumComboBox = addComboBox
     addLargeComboBox = addComboBox
+
     def addFontComboBox(
         self,
         *,
@@ -271,6 +292,7 @@ class RibbonPanel(QtWidgets.QFrame):
     addSmallFontComboBox = addFontComboBox
     addMediumFontComboBox = addFontComboBox
     addLargeFontComboBox = addFontComboBox
+
     def addLineEdit(
         self,
         *,
@@ -283,6 +305,7 @@ class RibbonPanel(QtWidgets.QFrame):
     addSmallLineEdit = addLineEdit
     addMediumLineEdit = addLineEdit
     addLargeLineEdit = addLineEdit
+
     def addTextEdit(
         self,
         *,
@@ -295,6 +318,7 @@ class RibbonPanel(QtWidgets.QFrame):
     addSmallTextEdit = addTextEdit
     addMediumTextEdit = addTextEdit
     addLargeTextEdit = addTextEdit
+
     def addPlainTextEdit(
         self,
         *,
@@ -307,6 +331,7 @@ class RibbonPanel(QtWidgets.QFrame):
     addSmallPlainTextEdit = addPlainTextEdit
     addMediumPlainTextEdit = addPlainTextEdit
     addLargePlainTextEdit = addPlainTextEdit
+
     def addLabel(
         self,
         text: str,
@@ -320,6 +345,7 @@ class RibbonPanel(QtWidgets.QFrame):
     addSmallLabel = addLabel
     addMediumLabel = addLabel
     addLargeLabel = addLabel
+
     def addProgressBar(
         self,
         *,
@@ -332,6 +358,7 @@ class RibbonPanel(QtWidgets.QFrame):
     addSmallProgressBar = addProgressBar
     addMediumProgressBar = addProgressBar
     addLargeProgressBar = addProgressBar
+
     def addSlider(
         self,
         *,
@@ -344,6 +371,7 @@ class RibbonPanel(QtWidgets.QFrame):
     addSmallSlider = addSlider
     addMediumSlider = addSlider
     addLargeSlider = addSlider
+
     def addSpinBox(
         self,
         *,
@@ -356,6 +384,7 @@ class RibbonPanel(QtWidgets.QFrame):
     addSmallSpinBox = addSpinBox
     addMediumSpinBox = addSpinBox
     addLargeSpinBox = addSpinBox
+
     def addDoubleSpinBox(
         self,
         *,
@@ -368,6 +397,7 @@ class RibbonPanel(QtWidgets.QFrame):
     addSmallDoubleSpinBox = addDoubleSpinBox
     addMediumDoubleSpinBox = addDoubleSpinBox
     addLargeDoubleSpinBox = addDoubleSpinBox
+
     def addDateEdit(
         self,
         *,
@@ -380,6 +410,7 @@ class RibbonPanel(QtWidgets.QFrame):
     addSmallDateEdit = addDateEdit
     addMediumDateEdit = addDateEdit
     addLargeDateEdit = addDateEdit
+
     def addTimeEdit(
         self,
         *,
@@ -392,6 +423,7 @@ class RibbonPanel(QtWidgets.QFrame):
     addSmallTimeEdit = addTimeEdit
     addMediumTimeEdit = addTimeEdit
     addLargeTimeEdit = addTimeEdit
+
     def addDateTimeEdit(
         self,
         *,
@@ -404,6 +436,7 @@ class RibbonPanel(QtWidgets.QFrame):
     addSmallDateTimeEdit = addDateTimeEdit
     addMediumDateTimeEdit = addDateTimeEdit
     addLargeDateTimeEdit = addDateTimeEdit
+
     def addTableWidget(
         self,
         *,
@@ -416,6 +449,7 @@ class RibbonPanel(QtWidgets.QFrame):
     addSmallTableWidget = addTableWidget
     addMediumTableWidget = addTableWidget
     addLargeTableWidget = addTableWidget
+
     def addTreeWidget(
         self,
         *,
@@ -428,6 +462,7 @@ class RibbonPanel(QtWidgets.QFrame):
     addSmallTreeWidget = addTreeWidget
     addMediumTreeWidget = addTreeWidget
     addLargeTreeWidget = addTreeWidget
+
     def addListWidget(
         self,
         *,
@@ -440,6 +475,7 @@ class RibbonPanel(QtWidgets.QFrame):
     addSmallListWidget = addListWidget
     addMediumListWidget = addListWidget
     addLargeListWidget = addListWidget
+
     def addCalendarWidget(
         self,
         *,
@@ -452,6 +488,7 @@ class RibbonPanel(QtWidgets.QFrame):
     addSmallCalendarWidget = addCalendarWidget
     addMediumCalendarWidget = addCalendarWidget
     addLargeCalendarWidget = addCalendarWidget
+
     def addSeparator(
         self,
         orientation=QtCore.Qt.Vertical,
@@ -466,6 +503,7 @@ class RibbonPanel(QtWidgets.QFrame):
     addSmallSeparator = addSeparator
     addMediumSeparator = addSeparator
     addLargeSeparator = addSeparator
+
     def addHorizontalSeparator(
         self,
         width=6,
@@ -479,6 +517,7 @@ class RibbonPanel(QtWidgets.QFrame):
     addSmallHorizontalSeparator = addHorizontalSeparator
     addMediumHorizontalSeparator = addHorizontalSeparator
     addLargeHorizontalSeparator = addHorizontalSeparator
+
     def addVerticalSeparator(
         self,
         width=6,
@@ -492,6 +531,7 @@ class RibbonPanel(QtWidgets.QFrame):
     addSmallVerticalSeparator = addVerticalSeparator
     addMediumVerticalSeparator = addVerticalSeparator
     addLargeVerticalSeparator = addVerticalSeparator
+
     def addGallery(
         self,
         minimumWidth=800,

--- a/pyqtribbon/ribbonbar.py
+++ b/pyqtribbon/ribbonbar.py
@@ -1,6 +1,6 @@
 import typing
 
-from PySide2 import QtCore, QtGui, QtWidgets
+from PySide import QtCore, QtGui, QtWidgets
 
 from .category import (
     RibbonCategory,

--- a/pyqtribbon/ribbonbar.py
+++ b/pyqtribbon/ribbonbar.py
@@ -122,7 +122,7 @@ class RibbonBar(QtWidgets.QMenuBar):
     def actionAt(self, QPoint):
         raise NotImplementedError("RibbonBar.actionAt() is not implemented in the ribbon bar.")
 
-    def actionGeometry(self, QAction):
+    def actionGeometry(self, QWidgetAction):
         raise NotImplementedError("RibbonBar.actionGeometry() is not implemented in the ribbon bar.")
 
     def activeAction(self):
@@ -143,10 +143,10 @@ class RibbonBar(QtWidgets.QMenuBar):
     def cornerWidget(self, corner=None, *args, **kwargs):
         raise NotImplementedError("RibbonBar.cornerWidget() is not implemented in the ribbon bar.")
 
-    def insertMenu(self, QAction, QMenu):
+    def insertMenu(self, QWidgetAction, QMenu):
         raise NotImplementedError("RibbonBar.insertMenu() is not implemented in the ribbon bar.")
 
-    def insertSeparator(self, QAction):
+    def insertSeparator(self, QWidgetAction):
         raise NotImplementedError("RibbonBar.insertSeparator() is not implemented in the ribbon bar.")
 
     def isDefaultUp(self):
@@ -155,7 +155,7 @@ class RibbonBar(QtWidgets.QMenuBar):
     def isNativeMenuBar(self):
         raise NotImplementedError("RibbonBar.isNativeMenuBar() is not implemented in the ribbon bar.")
 
-    def setActiveAction(self, QAction):
+    def setActiveAction(self, QWidgetAction):
         raise NotImplementedError("RibbonBar.setActiveAction() is not implemented in the ribbon bar.")
 
     def setCornerWidget(self, QWidget, corner=None, *args, **kwargs):

--- a/pyqtribbon/screenshotwindow.py
+++ b/pyqtribbon/screenshotwindow.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore, QtWidgets
+from PySide import QtCore, QtWidgets
 
 
 class RibbonScreenShotWindow(QtWidgets.QMainWindow):

--- a/pyqtribbon/separator.py
+++ b/pyqtribbon/separator.py
@@ -1,6 +1,6 @@
 import typing
 
-from PySide2 import QtCore, QtGui, QtWidgets
+from PySide import QtCore, QtGui, QtWidgets
 
 
 class RibbonSeparator(QtWidgets.QFrame):

--- a/pyqtribbon/tabbar.py
+++ b/pyqtribbon/tabbar.py
@@ -1,6 +1,6 @@
 import typing
 
-from PySide2 import QtCore, QtGui, QtWidgets
+from PySide import QtCore, QtGui, QtWidgets
 
 
 class RibbonTabBar(QtWidgets.QTabBar):

--- a/pyqtribbon/titlewidget.py
+++ b/pyqtribbon/titlewidget.py
@@ -1,6 +1,6 @@
 import typing
 
-from PySide2 import QtCore, QtGui, QtWidgets
+from PySide import QtCore, QtGui, QtWidgets
 
 from .menu import RibbonMenu
 from .tabbar import RibbonTabBar

--- a/pyqtribbon/toolbutton.py
+++ b/pyqtribbon/toolbutton.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore, QtWidgets
+from PySide import QtCore, QtWidgets
 
 from .constants import RibbonButtonStyle
 from .menu import RibbonMenu


### PR DESCRIPTION
Hi,

I really like your RibbonUI. Because I wanted to test it with a FreeCAD version which is build with QT6, i've created a Fork.
The changes I've made:
 - Changed PySide2 to PySide -> PySide is a special module in FreeCAD that handle the choice for PySide2 or PySide 6. See [https://wiki.freecad.org/PySide](url) for more information
 - Changed QAction to QWidgetAction to make the Ribbon work with both PySide2 and PySide 6.
 - Added a package xml. This because i added this Git as a custom repository to the addon manager. 
 - Added two pre-commit files: pre-commit-config.yaml and pre-commit-search-and-replace.yaml. When you work with, the second one will automaticly search for Pyside2 and PySide6 and replace it with PySide.

If you can use the changes feel free to merge or copy them.

Kind regards,

Paul Ebbers